### PR TITLE
fixed bug in populateQuaternion

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
@@ -315,7 +315,7 @@ Vector3f AP_ExternalAHRS_LORD::populateVector3f(const uint8_t* pkt, uint8_t offs
 
 Quaternion AP_ExternalAHRS_LORD::populateQuaternion(const uint8_t* pkt, uint8_t offset) {
     uint32_t tmp[4];
-    for (uint8_t j = 0; j < 3; j++) {
+    for (uint8_t j = 0; j < 4; j++) {
         tmp[j] = get4ByteField(pkt, offset + j * 4 + 2);
     }
 


### PR DESCRIPTION
populateQuaternion in ``` libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp``` had a bug where the loop counter was set to `< 3` instead of `< 4`. As a result the build would fail with the following error: 

```
../../libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp: In member function 'void AP_ExternalAHRS_LORD::parseIMU()':
../../libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp:191:25: error: '*((void*)& tmp +12)' may be used uninitialized in this function [-Werror=maybe-uninitialized]
                 quatNew = populateQuaternion(currPacket.payload, i);
```

Fixed the loop counter and now the code builds successfully