### PR TITLE
Fix temperature to fix corrections

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
@@ -252,7 +252,7 @@ void AP_ExternalAHRS_LORD::handleIMUPacket() {
         AP_ExternalAHRS::baro_data_message_t baro;
         baro.instance = 0;
         baro.pressure_pa = pressureNew;
-        //baro.temperature = -300;
+        baro.temperature = 25;
         AP::baro().handle_external(baro);
     }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
@@ -252,6 +252,7 @@ void AP_ExternalAHRS_LORD::handleIMUPacket() {
         AP_ExternalAHRS::baro_data_message_t baro;
         baro.instance = 0;
         baro.pressure_pa = pressureNew;
+        //setting temp to 25 effectively disables barometer temperature calibrations - this are performed by lord
         baro.temperature = 25;
         AP::baro().handle_external(baro);
     }


### PR DESCRIPTION
Changed temp to 25 causing barometer temp corrections to not change pressure.